### PR TITLE
Removal of recursion in favour of O(n) for loop #18

### DIFF
--- a/test/ParseMixedCommandsTest.gd
+++ b/test/ParseMixedCommandsTest.gd
@@ -171,10 +171,12 @@ func _test_nested_variable_conditional():
 			"nested_component": true
 		}
 		}
+	print("\tFirst Scenario...")
 	tester.set_states(state)
 	await tester.start_test(test_dialogue, test_name)
 	tester.assert_response("about to test nested variable in conditional.\ntrue target reached.", [], true)
 	
+	print("\tSecond Scenario...")
 	state["some_variable"]["nested_component"] = false
 	await tester.start_test(test_dialogue, test_name)
 	tester.assert_response("about to test nested variable in conditional.\nelse target reached.", [], true)


### PR DESCRIPTION
I removed the recursion function to allow for better readability for anyone to use, Either works fine now, having 1 variable input feels much nicer however

_nexted_state_reference didn't need inject modifier, my first implementation it was used to differentiate between if was text injection or eval expression.

One small QOL if possbible, i tried finding a variable that had the node name "start" "test_variable_injection_in_text" etc but couldn't find it. having any of the printerr() messages with the prefix of the dialogue node name would be ideal for debugging. example for "_test_conditional_missing_variable" being "Error['_test_conditional_missing_variable']: Can't find expression ' test_variable ' in the stateReference: {  }" or something to that effect. just having the node name inside would be perfect